### PR TITLE
Fix modal not showing when subscription ends

### DIFF
--- a/app/src/components/organisms/subscriptionModal/SubscriptionModal.tsx
+++ b/app/src/components/organisms/subscriptionModal/SubscriptionModal.tsx
@@ -120,8 +120,6 @@ const SubscriptionModal: FunctionComponent = () =>
     void router.push(url);
   };
 
-  console.log("isOnValidSubscription", isOnValidSubscription);
-
   return (
     <Modal
       opened={isOpened}

--- a/app/src/components/organisms/subscriptionModal/SubscriptionModal.tsx
+++ b/app/src/components/organisms/subscriptionModal/SubscriptionModal.tsx
@@ -23,7 +23,12 @@ const SubscriptionModal: FunctionComponent = () =>
 {
   const { isUserLoggedIn } = useContext(AuthStateContext);
   const router = useRouter();
-  const { generateStripeSessionUrl, isOnTrailSubscription, subscriptionDetails } = useSubscription();
+  const {
+    generateStripeSessionUrl,
+    isOnPaidSubscription,
+    isOnTrailSubscription,
+    subscriptionDetails
+  } = useSubscription();
 
   const [daysCheckedForSubscriptionEnds, setDaysCheckedForSubscriptionEnds] = useLocalStorage<string[]>({
     defaultValue: [],
@@ -78,16 +83,21 @@ const SubscriptionModal: FunctionComponent = () =>
 
   const [wasClosed, setWasClosed] = useState(false);
   const todayDateAsString = new Date().toISOString().split("T")[0] as string;
-  const isOpened = (
+  const isOnValidSubscription = isOnPaidSubscription || isOnTrailSubscription;
+  const isAuthenticated = isUserLoggedIn && !router.pathname.startsWith(paths.login) && !router.pathname.startsWith(paths.register);
+
+  // this check is to prevent modal flickering
+  if(!subscriptionDetails) { return null; }
+
+  const isOpened = ((isAuthenticated && !isOnValidSubscription) || (
     !wasClosed &&
     !daysCheckedForSubscriptionEnds?.includes(todayDateAsString) &&
     isOnTrailSubscription &&
-    (diffDays === 3 || diffDays === 1 || (diffDays != null && diffDays <= 0)) &&
-    isUserLoggedIn &&
-    !router.pathname.startsWith(paths.login) &&
-    !router.pathname.startsWith(paths.register)
-  ) ?? false;
-  const isModalLocked = diffDays == null || diffDays <= 0;
+    (diffDays === 3 || diffDays === 1 || (diffDays != null && diffDays <= 0)) && 
+    isAuthenticated
+  )) ?? false;
+
+  const isModalLocked = (diffDays == null || diffDays <= 0) || !isOnValidSubscription;
 
   const redirectToStripeCheckout = async (): Promise<void> => 
   {
@@ -109,6 +119,8 @@ const SubscriptionModal: FunctionComponent = () =>
 
     void router.push(url);
   };
+
+  console.log("isOnValidSubscription", isOnValidSubscription);
 
   return (
     <Modal


### PR DESCRIPTION
This pull request fixes an issue where the modal was not showing when the subscription ends. The issue was caused by incorrect conditions in the code that prevented the modal from being displayed. This PR updates the conditions to correctly show the modal when the subscription ends.